### PR TITLE
fix for `that.$(...) is undefined` when reloading results

### DIFF
--- a/app/javascripts/views/kingdom_list_view.js
+++ b/app/javascripts/views/kingdom_list_view.js
@@ -2,8 +2,6 @@ Checklist.KingdomListView = Ember.View.extend({
   templateName: 'kingdom_list_view',
   content: null,
 
-  isVisible: false,
-
   tagName: 'div',
 
   classNames: ['c1'],
@@ -99,10 +97,9 @@ Checklist.KingdomListView = Ember.View.extend({
   },
 
   didInsertElement: function() {
-    var that = this;
+    var that = this.$();
     $('#loading').fadeOut('fast', function() {
-      that.$().fadeIn();
-      that.set('isVisible',true);
+      that.fadeIn();
     });
 
     $('#content-aside').show();


### PR DESCRIPTION
We have a bug when reloading search results, which triggers randomly. The results are not displayed as in the screenshot, and a JS error is thrown pointing to line 104 in `Checklist.KingdomListView`.

I could not find a particular sequence that causes it, but a series of searches for different taxa, as well as language switches will eventually trigger it.

![checklist_issue_reloading_results](https://cloud.githubusercontent.com/assets/134055/14705051/a6ae4f1c-07af-11e6-9e25-0f4f698a3c1a.png)

That happens because we're referencing an Ember view element within an `didInsertElement` callback, and apparently there is some kind of race condition which results with the Ember object not being defined, even if the html element is present.

To fix that I removed references to the Ember object from that callback; it seems the logic that handled the `isVisible` property was not necessary (at least I cannot see any visual difference with or without it) and the `fadeIn` action is now called on a jQuery object.