### PR TITLE
fix for country names not getting translated

### DIFF
--- a/app/javascripts/controllers/geo_entities_controller.js
+++ b/app/javascripts/controllers/geo_entities_controller.js
@@ -1,14 +1,20 @@
 Checklist.GeoEntitiesController = Ember.ArrayController.extend({
   regions: null,
   countries: null,
+  needsReload: false,
 
   load: function(){
-    if (!this.get('regions.isLoaded')){
-      this.set('regions', Checklist.GeoEntity.find({geo_entity_types_set: '1'}));
+    if (!this.get('regions.isLoaded') || this.get('needsReload')){
+      this.set('regions', Checklist.GeoEntity.find({
+        geo_entity_types_set: '1', locale: Em.I18n.currentLocale
+      }));
     }
-    if (!this.get('countries.isLoaded')){
-      this.set('countries', Checklist.GeoEntity.find({geo_entity_types_set: '2'}));
+    if (!this.get('countries.isLoaded') || this.get('needsReload')){
+      this.set('countries', Checklist.GeoEntity.find({
+        geo_entity_types_set: '2', locale: Em.I18n.currentLocale
+      }));
     }
+    this.set('needsReload', false)
   }
 
 });

--- a/app/javascripts/routers/router.js
+++ b/app/javascripts/routers/router.js
@@ -108,6 +108,8 @@ Checklist.Router = Ember.Router.extend({
         } else {
           newState = router.get('currentState.name');
         }
+        var geoEntitiesController = router.get('geoEntitiesController');
+        geoEntitiesController.set('needsReload', true)
         router.transitionTo(newState, {locale: newLocale});
       },
 
@@ -119,6 +121,8 @@ Checklist.Router = Ember.Router.extend({
         } else {
           newState = router.get('currentState.name');
         }
+        var geoEntitiesController = router.get('geoEntitiesController');
+        geoEntitiesController.set('needsReload', true)
         router.transitionTo(newState, {locale: newLocale});
       },
 
@@ -130,6 +134,8 @@ Checklist.Router = Ember.Router.extend({
         } else {
           newState = router.get('currentState.name');
         }
+        var geoEntitiesController = router.get('geoEntitiesController');
+        geoEntitiesController.set('needsReload', true)
         router.transitionTo(newState, {locale: newLocale});
       }
     }),


### PR DESCRIPTION
Region / country / territory names do not refresh in either the locations drop down or the distribution lists when language version is changed.