### PR TITLE
Set width to 100% for section and images

### DIFF
--- a/app/stylesheets/_fancybox.scss
+++ b/app/stylesheets/_fancybox.scss
@@ -57,6 +57,8 @@
       font-style: italic;
     }
     .listing-section {
+      width: 100%;
+      img { width: 100%; }
       .listing-section-header {
         .appendix {
           width: 40%;


### PR DESCRIPTION
This is for [Logos chopped off by the edge of the listings box on the checklist website](https://www.pivotaltracker.com/story/show/137522705).
Just set the images to 100% width.