### PR TITLE
Sync develop to staging: harden deploy secrets handling

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,13 +29,21 @@ jobs:
     needs: determine-environment
     runs-on: self-hosted
     environment: ${{ needs.determine-environment.outputs.environment }}
+    # Only the secrets .kamal/secrets-common actually references. This job
+    # previously serialised the entire secrets context into one variable and
+    # picked through it at runtime, which handed every repository and
+    # environment secret to the job and wrote them all to a file on the
+    # self-hosted runner.
+    env:
+      CERTIFICATE_PEM: ${{ secrets.CERTIFICATE_PEM }}
+      PRIVATE_KEY_PEM: ${{ secrets.PRIVATE_KEY_PEM }}
     steps:
       - name: Set workflow start time
         run: |
           echo "START_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> $GITHUB_ENV
           echo "ACTION_TYPE=Deploy" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Notify deployment start
         id: notify-start
@@ -57,64 +65,11 @@ jobs:
           runner-name: ${{ runner.name }}
           start-time: ${{ env.START_TIME }}
 
-      - name: Export and validate kamal secrets
-        shell: bash
-        env:
-          SECRETS_JSON: ${{ toJSON(secrets) }}
-          KAMAL_SECRETS_FILE: ${{ needs.determine-environment.outputs.kamal-secrets-file }}
-        run: |
-          if [[ -z "$KAMAL_SECRETS_FILE" ]]; then
-            echo "Error: kamal secrets file path not provided."
-            exit 1
-          fi
-          if [[ ! -f "$KAMAL_SECRETS_FILE" ]]; then
-            echo "Error: $KAMAL_SECRETS_FILE file not found."
-            exit 1
-          fi
-
-          temp_secrets="$(mktemp)"
-          trap 'rm -f "$temp_secrets"' EXIT
-          printf '%s' "$SECRETS_JSON" > "$temp_secrets"
-
-          needed_vars=()
-          while IFS= read -r line; do
-            trimmed="$(echo "$line" | tr -d '\r' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
-            [[ -z "$trimmed" || "$trimmed" == \#* ]] && continue
-            [[ "$trimmed" != *=* ]] && continue
-
-            value="${trimmed#*=}"
-            value="${value#"${value%%[![:space:]]*}"}"
-            value="${value%"${value##*[![:space:]]}"}"
-
-            [[ "$value" != \$* ]] && continue
-            [[ "$value" == '$('* ]] && continue
-
-            if [[ "$value" == \$\{* ]]; then
-              if [[ "$value" =~ ^\$\{([A-Z0-9_]+) ]]; then
-                needed_vars+=("${BASH_REMATCH[1]}")
-              fi
-            elif [[ "$value" =~ ^\$([A-Z0-9_]+) ]]; then
-              needed_vars+=("${BASH_REMATCH[1]}")
-            fi
-          done < "$KAMAL_SECRETS_FILE"
-
-          IFS=$'\n' read -r -d '' -a unique_vars < <(printf '%s\n' "${needed_vars[@]}" | sort -u && printf '\0')
-
-          for var in "${unique_vars[@]}"; do
-            value=$(jq -r --arg key "$var" '.[$key] // empty' "$temp_secrets")
-            if [[ -z "$value" ]]; then
-              echo "Missing environment variable required in .kamal/secrets-common: ${var}" >&2
-              exit 1
-            fi
-
-            {
-              echo "${var}<<EOF"
-              echo "$value"
-              echo "EOF"
-            } >> "$GITHUB_ENV"
-          done
-
-          echo "✅ All required kamal secrets are validated and available as environment variables"
+      - name: Validate kamal secrets
+        uses: unepwcmc/devops-actions/.github/actions/validate-secrets@v1
+        with:
+          secrets-file: ${{ needs.determine-environment.outputs.kamal-secrets-file }}
+          environment: ${{ needs.determine-environment.outputs.environment }}
 
       - name: Deploy with Kamal v2
         uses: unepwcmc/devops-actions/.github/actions/kamal-v2.x-deploy@v1
@@ -123,8 +78,6 @@ jobs:
           working-directory: .
         env:
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
-          CERTIFICATE_PEM: ${{ secrets.CERTIFICATE_PEM }}
-          PRIVATE_KEY_PEM: ${{ secrets.PRIVATE_KEY_PEM }}
 
       - name: Set workflow end time and calculate duration
         if: always()


### PR DESCRIPTION
Brings `staging` in line with `develop`. Only change in the diff is the deploy workflow — no application code.

Stops the deploy job serialising the entire secrets context into `SECRETS_JSON` and writing it to a temp file on the self-hosted runner. Replaced with an explicit job-level `env:` listing exactly the 2 variables `.kamal/secrets-common` references, plus the `validate-secrets` action so missing secrets still fail with a clear error. Also `actions/checkout` v4 → v5 for the node24 runtime.

Merging deploys to staging. Same change is already green on `species-api` and `cites-compliance-tool` staging: deploy succeeded and both runs reported zero Node deprecation warnings.